### PR TITLE
Change the extension syntax

### DIFF
--- a/docs/fcp_dbc.rst
+++ b/docs/fcp_dbc.rst
@@ -52,7 +52,7 @@ Example
         sensor_id @2: u8,
     }
 
-    can SensorInformation extends SensorInformation {
+    impl can for SensorInformation {
         id: 100,
         device: "ecu1",
 

--- a/plugins/fcp_dbc/README.md
+++ b/plugins/fcp_dbc/README.md
@@ -44,7 +44,7 @@ struct SensorInformation {
     sensor_id @2: u8,
 }
 
-can SensorInformation extends SensorInformation {
+impl can for SensorInformation {
     id: 100,
     device: "ecu1",
 

--- a/plugins/fcp_dbc/tests/configs/001_basic_struct.fcp
+++ b/plugins/fcp_dbc/tests/configs/001_basic_struct.fcp
@@ -5,6 +5,6 @@ struct Foo {
     s2 @ 1: u8,
 }
 
-can Foo extends Foo {
+impl can for Foo {
     id: 10,
 }

--- a/plugins/fcp_dbc/tests/configs/002_nested_enum.fcp
+++ b/plugins/fcp_dbc/tests/configs/002_nested_enum.fcp
@@ -12,6 +12,6 @@ struct Foo {
     s3 @ 2: E,
 }
 
-can Foo extends Foo {
+impl can for Foo {
     id: 10,
 }

--- a/plugins/fcp_dbc/tests/configs/003_nested_struct.fcp
+++ b/plugins/fcp_dbc/tests/configs/003_nested_struct.fcp
@@ -11,6 +11,6 @@ struct Foo {
     s3 @2: Bar,
 }
 
-can Foo extends Foo {
+impl can for Foo {
     id: 10,
 }

--- a/plugins/fcp_dbc/tests/configs/004_nested_nested_struct.fcp
+++ b/plugins/fcp_dbc/tests/configs/004_nested_nested_struct.fcp
@@ -16,6 +16,6 @@ struct Foo {
     s3 @2: Bar,
 }
 
-can Foo extends Foo {
+impl can for Foo {
     id: 10,
 }

--- a/plugins/fcp_dbc/tests/configs/005_small_types.fcp
+++ b/plugins/fcp_dbc/tests/configs/005_small_types.fcp
@@ -6,6 +6,6 @@ struct Foo {
     s3 @2: u1,
 }
 
-can Foo extends Foo {
+impl can for Foo {
     id: 10,
 }

--- a/plugins/fcp_dbc/tests/configs/006_big_endian.fcp
+++ b/plugins/fcp_dbc/tests/configs/006_big_endian.fcp
@@ -5,7 +5,7 @@ struct Foo {
     s2 @1: u8,
 }
 
-can Foo extends Foo {
+impl can for Foo {
     id: 10,
 
     signal s2 {

--- a/plugins/fcp_dbc/tests/configs/007_muxed_signals.fcp
+++ b/plugins/fcp_dbc/tests/configs/007_muxed_signals.fcp
@@ -5,7 +5,7 @@ struct Foo {
     s2 @1: u8,
 }
 
-can Foo extends Foo {
+impl can for Foo {
     id: 10,
 
     signal s2 {

--- a/src/fcp/v2_parser.py
+++ b/src/fcp/v2_parser.py
@@ -22,7 +22,7 @@ from .error_logger import ErrorLogger
 
 fcp_parser = Lark(
     """
-    start: preamble (struct | enum | mod_expr | extension)*
+    start: preamble (struct | enum | mod_expr | impl)*
 
     preamble: "version" ":" string
 
@@ -34,7 +34,7 @@ fcp_parser = Lark(
     enum: comment* "enum" identifier "{" enum_field* "}"
     enum_field : comment* identifier "=" value ","
 
-    extension: identifier identifier "extends" identifier "{" (extension_field | signal_block)+ "}"
+    impl: "impl" identifier "for" identifier "{" (extension_field | signal_block)+ "}"
     signal_block: "signal" identifier "{" extension_field+ "}" ","
     extension_field: identifier ":" value ","
 
@@ -250,11 +250,12 @@ class FcpV2Transformer(Transformer):  # type: ignore
         return Ok(())
 
     @v_args(tree=True)  # type: ignore
-    def extension(self, tree: ParseTree) -> Nil:
+    def impl(self, tree: ParseTree) -> Nil:
         def is_signal_block(x: Any) -> bool:
             return isinstance(x, signal_block.SignalBlock)
 
-        protocol, name, type, *fields = tree.children
+        protocol, name, *fields = tree.children
+        type = name  # type and name are the same!
 
         signal_blocks = [field for field in fields if is_signal_block(field)]
         fields = [field for field in fields if not is_signal_block(field)]

--- a/tests/configs/syntax/005_extends.fcp
+++ b/tests/configs/syntax/005_extends.fcp
@@ -4,7 +4,7 @@ struct A {
     field1 @0: u8,
 }
 
-protocol1 A extends A {
+impl protocol1 for A {
     id: 2,
     signal field1 {
         bitstart: 0,


### PR DESCRIPTION
We will now use:

```
impl protocol for Struct {
    ...
}
```

Before the extension block started with an identifier, basically any word would fit. This meant that typos on high level blocks issued a very confusing error messaged about how the syntax for an extend block was wrong, even when the typo was on a struct or enum.

Another possible advantage is that now there's no different names for the extension and its type. They will always be the same, hopefully this will mean less confusion when debugging message definitions.

resolves #65 