### PR TITLE
Add support for yaml fcp configuration

### DIFF
--- a/fcp/__main__.py
+++ b/fcp/__main__.py
@@ -439,6 +439,16 @@ def read_fcp(json_file: str):
     print(spec)
 
 
+@click.command("write_json")
+@click.argument("json_file")
+def write_json(json_file: str):
+    logger = setup_logging()
+
+    spec = get_spec(json_file)
+
+    with open(os.path.splitext(json_file)[0] + ".json", "w") as f:
+        f.write(json.dumps(spec.compile(), indent=4))
+
 
 @click.group(invoke_without_command=True)
 @click.option("--version", is_flag=True, default=False)
@@ -474,6 +484,7 @@ main.add_command(fix)
 main.add_command(json_to_fcp2)
 main.add_command(read_fcp2)
 main.add_command(read_fcp)
+main.add_command(write_json)
 
 if __name__ == "__main__":
     main()

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     packages=find_packages(),
     entry_points={"console_scripts": ["fcp = fcp.__main__:main",],},
     install_requires=["jinja2", "click", "pyside2", "colorful", "cantools",
-                      "hjson", "pyyaml", "PySide2", "sqlalchemy", "appdirs", "result", "hypothesis", "requests", "parsimonious"],
+                      "hjson", "pyyaml", "PySide2", "sqlalchemy", "appdirs", "result", "hypothesis", "requests", "parsimonious", "ruamel.yaml"],
     long_description=long_description,
     long_description_content_type="text/markdown"
 )


### PR DESCRIPTION
Allow yaml to be used for fcp configuration.

The yaml implementation includes and extension that allows the usage of a `include!` directive. This directive permits including yaml files from another.

Overall the goal is to allow more manageable fcp configurations. 